### PR TITLE
:sparkles: Added CanvasColor property in ChoiceChip ThemeData

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -73,7 +73,14 @@ class _MyHomePageState extends State<MyHomePage> {
     await FilterListDialog.display<User>(
       context,
       hideSelectedTextCount: true,
-      themeData: FilterListThemeData(context),
+      themeData: FilterListThemeData(
+        context,
+        backgroundColor: Color.fromARGB(255, 80, 80, 80),
+        choiceChipTheme: ChoiceChipThemeData(
+          backgroundColor: Color.fromARGB(255, 77, 77, 77),
+          canvasColor: Colors.transparent,
+        ),
+      ),
       headlineText: 'Select Users',
       height: 500,
       listData: userList,

--- a/lib/src/theme/choice_chip_theme.dart
+++ b/lib/src/theme/choice_chip_theme.dart
@@ -77,6 +77,7 @@ class ChoiceChipThemeData with Diagnosticable {
     this.padding,
     this.labelPadding = const EdgeInsets.symmetric(horizontal: 4.0),
     this.margin = const EdgeInsets.symmetric(horizontal: 10.0),
+    this.canvasColor,
   });
 
   factory ChoiceChipThemeData.light(BuildContext context) =>
@@ -178,6 +179,10 @@ class ChoiceChipThemeData with Diagnosticable {
   /// The margin around choice chip
   final EdgeInsetsGeometry margin;
 
+  /// Give a CanvasColor for ChoiceChips
+  /// Default value is [Colors.transparent]
+  final Color? canvasColor;
+
   /// Creates a copy of this theme, but with the given fields replaced with
   /// the new values.
   ChoiceChipThemeData copyWith({
@@ -198,6 +203,7 @@ class ChoiceChipThemeData with Diagnosticable {
     EdgeInsetsGeometry? padding,
     EdgeInsetsGeometry? labelPadding,
     EdgeInsetsGeometry? margin,
+    Color? canvasColor,
   }) {
     return ChoiceChipThemeData(
       selectedTextStyle: selectedTextStyle ?? this.selectedTextStyle,
@@ -216,6 +222,7 @@ class ChoiceChipThemeData with Diagnosticable {
       padding: padding ?? this.padding,
       labelPadding: labelPadding ?? this.labelPadding,
       margin: margin ?? this.margin,
+      canvasColor: canvasColor ?? this.canvasColor,
     );
   }
 
@@ -244,6 +251,7 @@ class ChoiceChipThemeData with Diagnosticable {
       padding: EdgeInsetsGeometry.lerp(a.padding, b.padding, t),
       labelPadding: EdgeInsetsGeometry.lerp(a.labelPadding, b.labelPadding, t),
       margin: EdgeInsetsGeometry.lerp(a.margin, b.margin, t)!,
+      canvasColor: Color.lerp(a.canvasColor, b.canvasColor, t),
     );
   }
 
@@ -266,7 +274,8 @@ class ChoiceChipThemeData with Diagnosticable {
           selectedShadowColor == other.selectedShadowColor &&
           padding == other.padding &&
           labelPadding == other.labelPadding &&
-          margin == other.margin;
+          margin == other.margin &&
+          canvasColor == other.canvasColor;
 
   @override
   int get hashCode =>
@@ -284,7 +293,8 @@ class ChoiceChipThemeData with Diagnosticable {
       selectedShadowColor.hashCode ^
       padding.hashCode ^
       labelPadding.hashCode ^
-      margin.hashCode;
+      margin.hashCode ^
+      canvasColor.hashCode;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -312,5 +322,6 @@ class ChoiceChipThemeData with Diagnosticable {
     properties.add(
         DiagnosticsProperty<EdgeInsetsGeometry>('labelPadding', labelPadding));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin));
+    properties.add(DiagnosticsProperty<Color>('canvasColor', canvasColor));
   }
 }

--- a/lib/src/widget/choice_chip_widget.dart
+++ b/lib/src/widget/choice_chip_widget.dart
@@ -53,21 +53,26 @@ class ChoiceChipWidget<T> extends StatelessWidget {
           )
         : Padding(
             padding: theme.margin,
-            child: ChoiceChip(
-              labelPadding: theme.labelPadding,
-              padding: theme.padding,
-              backgroundColor: getBackgroundColor(context),
-              selectedColor: theme.selectedBackgroundColor,
-              label: Text('$text'),
-              labelStyle: getSelectedTextStyle(context),
-              visualDensity: theme.visualDensity,
-              selected: selected!,
-              onSelected: onSelected,
-              elevation: theme.elevation,
-              side: getSide(context),
-              shape: getShape(context),
-              shadowColor: theme.shadowColor,
-              selectedShadowColor: theme.selectedShadowColor,
+            child: Theme(
+              data: ThemeData().copyWith(
+                canvasColor: theme.canvasColor ?? Colors.transparent,
+              ),
+              child: ChoiceChip(
+                labelPadding: theme.labelPadding,
+                padding: theme.padding,
+                backgroundColor: getBackgroundColor(context),
+                selectedColor: theme.selectedBackgroundColor,
+                label: Text('$text'),
+                labelStyle: getSelectedTextStyle(context),
+                visualDensity: theme.visualDensity,
+                selected: selected!,
+                onSelected: onSelected,
+                elevation: theme.elevation,
+                side: getSide(context),
+                shape: getShape(context),
+                shadowColor: theme.shadowColor,
+                selectedShadowColor: theme.selectedShadowColor,
+              ),
             ),
           );
   }


### PR DESCRIPTION
**Added a additional property for ChoiceChip in ThemeData.**
Recently facing a problem of white background Color noise around ChoiceChip. This is easy to solve by passing a CanvasColor in its theme property. But got no option for this, so i added it in. And the issue is Solved.
Now it gives a clean and sharp view of ChoiceChip.

You can check the problem below that i was talking about.

![sample-01](https://user-images.githubusercontent.com/60544576/181605295-2165773f-8ed7-4020-8eb8-edd1f027400e.png)
