### PR TITLE
FIX - The filter applies it to the filtered list instead of to all items in the initial list.

### DIFF
--- a/lib/src/state/filter_state.dart
+++ b/lib/src/state/filter_state.dart
@@ -5,12 +5,14 @@ class FilterState<K> extends ListenableState {
   FilterState({List<K>? allItems, List<K>? selectedItems}) {
     this.selectedItems = selectedItems;
     items = allItems;
+    _allItems = allItems;
   }
 
   static FilterState<T> of<T>(BuildContext context) =>
       StateProvider.of<FilterState<T>>(context);
 
   /// List of all items
+  List<K>? _allItems;
   List<K>? _items;
   List<K>? get items => _items;
   set items(List<K>? value) {
@@ -57,7 +59,7 @@ class FilterState<K> extends ListenableState {
 
   // perform filter operation
   void filter(bool Function(K) filter) {
-    _items = _items!.where(filter).toList();
+    _items = _allItems!.where(filter).toList();
     notifyListeners();
   }
 


### PR DESCRIPTION
The filter applies it to the filtered list instead of to all items in the initial list.

The filter method of the `FilterState` class applies the filter on the items (_items) containing the items that were filtered as you type in the search field.

If a variable is added, e.g. **List<K>? _allItems**; in which the original list is stored as follows:

```
FilterState({List<K>? allItems, List<K>? selectedItems}) {
    this.selectedItems = selectedItems;
    items = allItems;
    _allItems = allItems;
  }
```

And you modify the filter function to use the **_allItems** variable instead of _items, the problem is solved.

```
// perform filter operation
  void filter(bool Function(K) filter) {
    _items = _allItems!.where(filter).toList();
    notifyListeners();
  }
```

You might consider doing a merge of this change? 