### PR TITLE
Update FilterState when selection changes + rebuild on change

### DIFF
--- a/lib/src/filter_list_delegate.dart
+++ b/lib/src/filter_list_delegate.dart
@@ -340,7 +340,6 @@ One of the tileLabel or suggestionBuilder is required
   }
 
   void onItemSelect(BuildContext context, T item) {
-    final state = StateProvider.of<FilterState<T>>(context);
     if (enableOnlySingleSelection) {
       onApplyButtonClick([item]);
       close(context, null);
@@ -356,6 +355,7 @@ One of the tileLabel or suggestionBuilder is required
         }
         selectedItems!.add(item);
       }
+      final state = StateProvider.of<FilterState<T>>(context);
       state.selectedItems = selectedItems;
       final qq = query;
       query = '';

--- a/lib/src/filter_list_delegate.dart
+++ b/lib/src/filter_list_delegate.dart
@@ -269,7 +269,10 @@ One of the tileLabel or suggestionBuilder is required
         theme: theme ?? FilterListDelegateThemeData(),
         child: Builder(
           builder: (BuildContext innerContext) {
-            final state = StateProvider.of<FilterState<T>>(innerContext);
+            final state = StateProvider.of<FilterState<T>>(
+              innerContext,
+              rebuildOnChange: true,
+            );
             return ListView.builder(
               itemCount: state.items!.length,
               itemBuilder: (context, index) {
@@ -337,6 +340,7 @@ One of the tileLabel or suggestionBuilder is required
   }
 
   void onItemSelect(BuildContext context, T item) {
+    final state = StateProvider.of<FilterState<T>>(context);
     if (enableOnlySingleSelection) {
       onApplyButtonClick([item]);
       close(context, null);
@@ -352,6 +356,7 @@ One of the tileLabel or suggestionBuilder is required
         }
         selectedItems!.add(item);
       }
+      state.selectedItems = selectedItems;
       final qq = query;
       query = '';
       query = qq;


### PR DESCRIPTION
**Motivation** 

Maybe i missed something but in the `FilterListDelegate` taping a tile updates the local `selectedItems` but not the state one.
The widget does not rebuild so the UI does not reflect the proper selection

**Before**


https://github.com/user-attachments/assets/c74dee8d-15b0-4b1d-bf21-6cecf3852748

**After **

https://github.com/user-attachments/assets/f0b607d6-c158-4f87-beb9-28303a6daa23



